### PR TITLE
process timeout sites

### DIFF
--- a/src/trackers/build-trackers.js
+++ b/src/trackers/build-trackers.js
@@ -56,7 +56,7 @@ console.log(`Found ${summary.trackers} ${chalk.green("trackers")}`)
 console.log(`Found ${summary.entities.length} ${chalk.green("entities")}`)
 console.log(chalk.green("Done"))
 
-fs.writeFileSync(`${sharedData.config.trackerDataLoc}/build-data/generated/releasestats.txt`, `${summary.trackers} trackers\n${summary.entities.length} entities`)
+fs.writeFileSync(`${sharedData.config.trackerDataLoc}/build-data/generated/releasestats.txt`, `${summary.trackers} domains\n${summary.entities.length} entities`)
 
 function log (msg) {
     if (sharedData.config.verbose) {

--- a/src/trackers/process-crawl.js
+++ b/src/trackers/process-crawl.js
@@ -22,7 +22,7 @@ function processSite(siteName) {
     const siteData = JSON.parse(fs.readFileSync(`${sharedData.config.crawlerDataLoc}/${siteName}`, 'utf8'))
 
     // check that the crawl for this site finished and has data to process
-    if (!siteData.initialUrl || siteData.timeout || !(siteData.data.requests && siteData.data.requests.length)) {
+    if (!siteData.initialUrl || !(siteData.data.requests && siteData.data.requests.length)) {
         crawl.stats.requestsSkipped += 1
         bar.tick()
         return


### PR DESCRIPTION
- Process sites that timed out. There's still useful request data
- Rename trackers -> domains in release stats file