### PR TITLE
Cname Resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ npm run apply-entity-changes
 
 `npm run build`
 
-Note that if you wish to resolve CNAME's, node version 12+ is required.
+Note that if you wish to resolve CNAME's, node version 12+ is required. You can disable CNAME resolution by setting the option treatCnameAsFirstParty=true and keepFirstParty=false in the config file.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ npm run apply-entity-changes
 
 `npm run build`
 
+Note that if you wish to resolve CNAME's, node version 12+ is required.
+
 ## Contributing
 
 ### Reporting bugs

--- a/config.json
+++ b/config.json
@@ -8,5 +8,7 @@
     },
     "keepFirstParty": false,
     "treatCnameAsFirstParty": false,
-    "parallelism": 100
+    "parallelism": 100,
+    "verbose": false,
+    "cname_ignore_subdomains": ["", "www"]
 }

--- a/config.json
+++ b/config.json
@@ -7,5 +7,6 @@
         "addSurrogates": false
     },
     "keepFirstParty": false,
-    "treatCnameAsFirstParty": false
+    "treatCnameAsFirstParty": false,
+    "parallelism": 100
 }

--- a/config.json
+++ b/config.json
@@ -5,5 +5,7 @@
     "performanceDataLoc": "path to your 3rd party performance directory",
     "flags": {
         "addSurrogates": false
-    }
+    },
+    "keepFirstParty": false,
+    "treatCnameAsFirstParty": false
 }

--- a/src/trackers/classes/commonRequest.js
+++ b/src/trackers/classes/commonRequest.js
@@ -19,7 +19,7 @@ class CommonRequest {
         this.cookies = 0
         this.fpStd = 0
         this.fpAvg = 0
-        this.cnames = []
+        this.cnames = request.wasCNAME ? [_cnameRecord(request)] : []
     }
 
     update (request, site) {
@@ -38,6 +38,13 @@ function _escapeUrl (request) {
     }
 
     return rule.replace(/(\(|\)|\/|\?|\.|\||\[)/g,'\\$1')
+}
+
+function _cnameRecord(request) {
+    return {
+        "original": request.originalSubdomain,
+        "resolved": request.data.subdomain + "." + request.data.domain
+    }
 }
 
 function _update (commonReq, newReq, site) {
@@ -59,10 +66,7 @@ function _update (commonReq, newReq, site) {
         }
 
         if (newReq.wasCNAME) {
-            commonReq.cnames.push({
-                "original": newReq.originalSubdomain,
-                "resolved": newReq.data.subdomain + "." + newReq.data.domain
-            })
+            commonReq.cnames.push(_cnameRecord(newReq))
         }
     }
 }

--- a/src/trackers/classes/commonRequest.js
+++ b/src/trackers/classes/commonRequest.js
@@ -61,7 +61,7 @@ function _update (commonReq, newReq, site) {
         if (newReq.wasCNAME) {
             commonReq.cnames.push({
                 "original": newReq.originalSubdomain,
-                "cname": newReq.data.subdomain + "." + newReq.data.domain
+                "resolved": newReq.data.subdomain + "." + newReq.data.domain
             })
         }
     }

--- a/src/trackers/classes/commonRequest.js
+++ b/src/trackers/classes/commonRequest.js
@@ -40,6 +40,15 @@ function _escapeUrl (request) {
     return rule.replace(/(\(|\)|\/|\?|\.|\||\[)/g,'\\$1')
 }
 
+function _containsCnameRecord(commonReq, record) {
+    for (let cReq of commonReq.cnames) {
+        if (cReq.original === record.original && cReq.resolved === record.resolved) {
+            return true
+        }
+    }
+    return false
+}
+
 function _cnameRecord(request) {
     return {
         "original": request.originalSubdomain,
@@ -66,7 +75,10 @@ function _update (commonReq, newReq, site) {
         }
 
         if (newReq.wasCNAME) {
-            commonReq.cnames.push(_cnameRecord(newReq))
+            let record = _cnameRecord(newReq)
+            if (!_containsCnameRecord(commonReq, record)) {
+                commonReq.cnames.push(record)
+            }
         }
     }
 }

--- a/src/trackers/classes/commonRequest.js
+++ b/src/trackers/classes/commonRequest.js
@@ -1,3 +1,5 @@
+const cname = require('./../helpers/cname.js')
+
 class CommonRequest {
     constructor (request, site) {
         this.host = request.domain
@@ -19,7 +21,7 @@ class CommonRequest {
         this.cookies = 0
         this.fpStd = 0
         this.fpAvg = 0
-        this.cnames = request.wasCNAME ? [_cnameRecord(request)] : []
+        this.cnames = request.wasCNAME ? [cname.createCnameRecord(request)] : []
     }
 
     update (request, site) {
@@ -40,21 +42,7 @@ function _escapeUrl (request) {
     return rule.replace(/(\(|\)|\/|\?|\.|\||\[)/g,'\\$1')
 }
 
-function _containsCnameRecord(commonReq, record) {
-    for (let cReq of commonReq.cnames) {
-        if (cReq.original === record.original && cReq.resolved === record.resolved) {
-            return true
-        }
-    }
-    return false
-}
 
-function _cnameRecord(request) {
-    return {
-        "original": request.originalSubdomain,
-        "resolved": request.data.subdomain + "." + request.data.domain
-    }
-}
 
 function _update (commonReq, newReq, site) {
     // update common request with new data only once for each site. If a site has 100s of requests
@@ -75,8 +63,8 @@ function _update (commonReq, newReq, site) {
         }
 
         if (newReq.wasCNAME) {
-            let record = _cnameRecord(newReq)
-            if (!_containsCnameRecord(commonReq, record)) {
+            let record = cname.createCnameRecord(newReq)
+            if (!cname.containsCnameRecord(commonReq.cnames, record)) {
                 commonReq.cnames.push(record)
             }
         }

--- a/src/trackers/classes/commonRequest.js
+++ b/src/trackers/classes/commonRequest.js
@@ -19,6 +19,7 @@ class CommonRequest {
         this.cookies = 0
         this.fpStd = 0
         this.fpAvg = 0
+        this.cnames = []
     }
 
     update (request, site) {
@@ -55,6 +56,13 @@ function _update (commonReq, newReq, site) {
         
         if (newReq.setsCookies) {
             commonReq.cookiesOn++
+        }
+
+        if (newReq.wasCNAME) {
+            commonReq.cnames.push({
+                "original": newReq.originalSubdomain,
+                "cname": newReq.data.subdomain + "." + newReq.data.domain
+            })
         }
     }
 }

--- a/src/trackers/classes/crawl.js
+++ b/src/trackers/classes/crawl.js
@@ -25,6 +25,8 @@ class Crawl {
         // summary of 3p requests seen in the crawl
         this.commonRequests = {}
 
+        // Sites that are CNAME cloaked as first party.
+        this.domainCloaks = {}
     }
     
     writeSummaries () {
@@ -59,6 +61,10 @@ function _processSite (crawl, site) {
 
         if (site.uniqueDomains[domain].setsCookies) {
             crawl.domainCookies[domain] ? crawl.domainCookies[domain]++ : crawl.domainCookies[domain] = 1
+        }
+
+        if (site.uniqueDomains[domain].usesCNAMECloaking) {
+            crawl.domainCloaks[domain] ? crawl.domainCloaks[domain]++ : crawl.domainCloaks[domain] = 1
         }
     })
 
@@ -109,6 +115,11 @@ function _getDomainSummaries (crawl) {
     // calculate average fp
     Object.keys(crawl.domainFingerprinting).forEach(domain => {
         domainSummary[domain].fp = median(crawl.domainFingerprinting[domain]) + std(crawl.domainFingerprinting[domain])
+    })
+
+    // How often does this domain appear cloaked?
+    Object.keys(crawl.domainCloaks).forEach(domain => {
+        domainSummary[domain].cloaked = crawl.domainCloaks[domain] / crawl.domainPrevalence[domain]
     })
 
     return domainSummary

--- a/src/trackers/classes/request.js
+++ b/src/trackers/classes/request.js
@@ -3,25 +3,30 @@ const ParsedUrl = require('./../helpers/parseUrl.js')
 
 class Request {
     constructor (reqData, site) {
-        this.url = reqData.url
+        this.site = site
+        this.extractURLData(reqData.url)
         this.type = reqData.type
-        this.data = new ParsedUrl(this.url)
-        this.domain = this.data.domain
-        this.host = this.data.hostname
-        this.path = this.data.path
-
-        this.owner = _getRequestOwner(this.data.domain)
-
         this.headers = reqData.responseHeaders || {}
-
-        this.apis = site.siteData.data.apis.callStats[this.url] || {}
-
         this.setsCookies = _setsCookies(this)
-
         this.isTracking = false
         this.fingerprintScore = _getFPScore(Object.keys(this.apis))
+        // if this request uses a third party CNAME, keep data here
+        this.wasCNAME = false
+        this.originalSubdomain = undefined
+    }
 
-        this.isFirstParty = _isFirstParty(this, site)
+    /**
+     * Extract relevant data from the URL. Sets properties of object.
+     * @param {string} url - the URL to analyze
+     */
+    extractURLData(url) {
+        this.url = url
+        this.data = new ParsedUrl(url)
+        this.domain = this.data.domain
+        this.host = this.data.hostname
+        this.path = this.path || this.data.path
+        this.owner = _getRequestOwner(this.data.domain)
+        this.apis = this.site.siteData.data.apis.callStats[url] || {}
     }
 }
 
@@ -36,14 +41,6 @@ function _getFPScore (apis) {
         totalFP += shared.abuseScores[api] || 1
         return totalFP
     },0)
-}
-
-function _isFirstParty (req, site) {
-    if (req.domain === site.domain || ((req.owner && site.owner) && req.owner === site.owner)) {
-        return true
-    }
-    return false
-    
 }
 
 function _setsCookies (req) {

--- a/src/trackers/classes/rule.js
+++ b/src/trackers/classes/rule.js
@@ -10,6 +10,7 @@ class Rule {
         this.apis = newRuleData.apis
         this.sites = newRuleData.sites
         this.prevalence = +(newRuleData.sites / totalSites).toPrecision(3)
+        this.cnames = newRuleData.cnames
     }
 }
 

--- a/src/trackers/classes/site.js
+++ b/src/trackers/classes/site.js
@@ -1,7 +1,7 @@
 const Request = require('./request.js')
 const shared = require('./../helpers/sharedData.js')
 const ParsedUrl = require('./../helpers/parseUrl.js')
-const resolveCname = require('./../helpers/cname.js')
+const cname = require('./../helpers/cname.js')
 
 class Site {
     constructor (siteData) {
@@ -125,7 +125,7 @@ async function _processRequest (requestData, site) {
         !shared.config.treatCnameAsFirstParty &&
         !isRootSite(request, site)
         ) {
-        let cnames = await resolveCname(request.url)
+        let cnames = await cname.resolveCname(request.url)
         if(cnames) {
             for (let cname of cnames) {
                 if (!site.isFirstParty(cname)) {

--- a/src/trackers/classes/site.js
+++ b/src/trackers/classes/site.js
@@ -1,6 +1,7 @@
 const Request = require('./request.js')
 const shared = require('./../helpers/sharedData.js')
 const ParsedUrl = require('./../helpers/parseUrl.js')
+const resolveCname = require('./../helpers/cname.js')
 
 class Site {
     constructor (siteData) {
@@ -23,11 +24,18 @@ class Site {
         this.requests = []
 
         this.owner = shared.entityMap.get(this.domain)
+
+        this.isFirstParty = _isFirstParty.bind(this)
+
+        this.cnameCloaks = {}
+
+        this.analyzeRequest = _analyzeRequest.bind(this)
     }
 
-    processRequest (requestData) {
-        _processRequest(requestData, this)
+    async processRequest (requestData) {
+        await _processRequest(requestData, this)
     }
+
 }
 
 // Cookie data from the crawler has the domain and path split
@@ -41,13 +49,26 @@ function _getCookies (siteData) {
     }, [])
 }
 
-function _processRequest (requestData, site) {
-    const request = new Request(requestData, site)
-
-    if (request.isFirstParty && !shared.config.keepFirstParty) {
-        return
+/**
+ * Test if the given URL is in this first party set.
+ * @param {string} url - url to test against.
+ * @returns {bool} True if the url is in this sites first party set.
+ */
+function _isFirstParty(url) {
+    let data = new ParsedUrl(url)
+    let dataOwner = shared.entityMap.get(data.domain)
+    if (data.domain === this.domain || ((dataOwner && this.owner) && dataOwner === this.owner)) {
+        return true
     }
+    return false
+}
 
+/**
+ *  Analyze a site for tracking or fingerprinting behaviors
+ *  @param {Request} request - The request object
+ *  @param {Site} site - the current site object
+ */
+function _analyzeRequest(request, site) {
     if (request.setsCookies || Object.keys(request.apis).length) {
         request.isTracking = true
     }
@@ -72,6 +93,40 @@ function _processRequest (requestData, site) {
         site.uniqueDomains[request.domain].setsCookies = true
     }
 
+    if (request.wasCNAME) {
+        site.uniqueDomains[request.domain].usesCNAMECloaking = true
+    }
+}
+
+/**
+ *  Process a single request, resolve CNAME's (if any)
+ *  @param {Object} requestData - The raw request data
+ *  @param {Site} site - the current site object
+ */
+async function _processRequest (requestData, site) {
+    let request = new Request(requestData, site)
+
+    if (site.isFirstParty(request.url) && !shared.config.treatCnameAsFirstParty) {
+        let cnames = await resolveCname(request.url)
+        if(cnames) {
+            for (let cname of cnames) {
+                if (!site.isFirstParty(cname)) {
+                    // console.log(`Third Party CNAME: ${request.data.subdomain}.${request.data.domain} -> ${cname}`)
+                    let origSubDomain = request.data.subdomain + "." + request.data.domain
+                    site.cnameCloaks[cname] = request.data.subdomain + "." + request.data.domain
+                    request.extractURLData(cname)
+                    request.wasCNAME = true
+                    request.originalSubdomain = origSubDomain
+                }
+            }
+        }
+    }
+
+    if (site.isFirstParty(request.url) && !shared.config.keepFirstParty) {
+        return
+    }
+
+    site.analyzeRequest(request, site)
     site.requests.push(request)
 }
 

--- a/src/trackers/classes/site.js
+++ b/src/trackers/classes/site.js
@@ -123,7 +123,8 @@ async function _processRequest (requestData, site) {
     // If this request is a subdomain of the site, see if it is cnamed
     if (site.isFirstParty(request.url) &&
         !shared.config.treatCnameAsFirstParty &&
-        !isRootSite(request, site)
+        !isRootSite(request, site) &&
+        !cname.isSubdomainExcluded(request.data)
         ) {
         let cnames = await cname.resolveCname(request.url)
         if(cnames) {

--- a/src/trackers/classes/tracker.js
+++ b/src/trackers/classes/tracker.js
@@ -57,6 +57,7 @@ class Tracker {
                 this.cnames.push(record)
             }
         })
+        this.cnames.sort((a,b) => a.original.localeCompare(b.original))
     }
 
     addSurrogates () {

--- a/src/trackers/classes/tracker.js
+++ b/src/trackers/classes/tracker.js
@@ -14,6 +14,7 @@ class Tracker {
         this.prevalence = +prevalence.toPrecision(3)
         this.sites = Math.round(prevalence * crawledSiteTotal)
         this.subdomains = []
+        this.cnames = []
 
         this.fingerprinting = getFpRank(sharedData.domains[this.domain].fp || 0)
         this.resources = []
@@ -50,6 +51,7 @@ class Tracker {
     addRule (rule) {
         this.resources.push(rule)
         this.subdomains = [...new Set(this.subdomains.concat(rule.subdomains))]
+        this.cnames = [...new Set(this.cnames.concat(rule.cnames))]
     }
 
     addSurrogates () {

--- a/src/trackers/classes/tracker.js
+++ b/src/trackers/classes/tracker.js
@@ -53,7 +53,7 @@ class Tracker {
         this.resources.push(rule)
         this.subdomains = [...new Set(this.subdomains.concat(rule.subdomains))]
         rule.cnames.forEach(record => {
-            if (cname.containsCnameRecord(this.cnames, record)) {
+            if (!cname.containsCnameRecord(this.cnames, record)) {
                 this.cnames.push(record)
             }
         })

--- a/src/trackers/classes/tracker.js
+++ b/src/trackers/classes/tracker.js
@@ -2,6 +2,7 @@ const tldjs = require('tldjs')
 const performanceHelper = require('./../helpers/getPerformance.js')
 const sharedData = require('./../helpers/sharedData.js')
 const getFpRank = require('./../helpers/getFingerprintRank.js')
+const cname = require('./../helpers/cname.js')
 
 class Tracker {
     constructor(trackerData, crawledSiteTotal) {
@@ -51,7 +52,11 @@ class Tracker {
     addRule (rule) {
         this.resources.push(rule)
         this.subdomains = [...new Set(this.subdomains.concat(rule.subdomains))]
-        this.cnames = [...new Set(this.cnames.concat(rule.cnames))]
+        rule.cnames.forEach(record => {
+            if (cname.containsCnameRecord(this.cnames, record)) {
+                this.cnames.push(record)
+            }
+        })
     }
 
     addSurrogates () {

--- a/src/trackers/helpers/cname.js
+++ b/src/trackers/helpers/cname.js
@@ -4,6 +4,7 @@
 
 const dns = require('dns').promises
 const ParsedUrl = require('./parseUrl.js')
+const shared = require('./sharedData.js')
 
 
 const cache = {}
@@ -62,6 +63,24 @@ class CNAME {
             "original": request.originalSubdomain,
             "resolved": request.data.subdomain + "." + request.data.domain
         }
+    }
+
+    /**
+     * Check whether this subdomain should be exluded from cname lookups.
+     * Initially sites like the root domain and www domains, since they 
+     * generally only resolve to CDN's.
+     * @param {ParsedURL} url - a ParsedURL object.
+     * @returns {boolean} true if subdomain is in the ignore list.
+     */
+    static isSubdomainExcluded(url) {
+        if (shared.config.cname_ignore_subdomains) {
+            for (let subdomain of shared.config.cname_ignore_subdomains) {
+                if (url.subdomain === subdomain) {
+                    return true
+                }
+            }
+        }
+        return false
     }
 }
 

--- a/src/trackers/helpers/cname.js
+++ b/src/trackers/helpers/cname.js
@@ -1,0 +1,38 @@
+/**
+ * Handle CNAME DNS lookups and common errors that we can safely ignore.
+ */
+
+const dns = require('dns').promises
+const ParsedUrl = require('./parseUrl.js')
+
+const cache = {}
+
+/*
+ * Attempt to look up a CNAME for a given hostname
+ * @param {string} url - url to run the check on.
+ *
+ * @return {Promise} The cname resolution
+ */
+async function resolveCname(url) {
+    url = ParsedUrl.parse(url)
+    if (url.hostname in cache) {
+        return cache[url.hostname]
+    }
+    if (url.protocol.startsWith("chrome-extension")) {
+        return undefined
+    }
+    try {
+        let cname = await dns.resolveCname(url.hostname)
+        cache[url.hostname] = cname
+    } catch (e) {
+        if (e.message && !(
+            e.message.includes("ENODATA") ||
+            e.message.includes("chrome-extension"))) {
+            console.log(e)
+            return undefined
+        }
+    }
+    return cache[url.hostname]
+}
+
+module.exports = resolveCname

--- a/src/trackers/helpers/cname.js
+++ b/src/trackers/helpers/cname.js
@@ -5,34 +5,64 @@
 const dns = require('dns').promises
 const ParsedUrl = require('./parseUrl.js')
 
+
 const cache = {}
 
-/*
- * Attempt to look up a CNAME for a given hostname
- * @param {string} url - url to run the check on.
- *
- * @return {Promise} The cname resolution
- */
-async function resolveCname(url) {
-    url = ParsedUrl.parse(url)
-    if (url.hostname in cache) {
-        return cache[url.hostname]
-    }
-    if (url.protocol.startsWith("chrome-extension")) {
-        return undefined
-    }
-    try {
-        let cname = await dns.resolveCname(url.hostname)
-        cache[url.hostname] = cname
-    } catch (e) {
-        if (e.message && !(
-            e.message.includes("ENODATA") ||
-            e.message.includes("ENOTFOUND"))) {
-            console.log(e)
+class CNAME {
+    /*
+     * Attempt to look up a CNAME for a given hostname
+     * @param {string} url - url to run the check on.
+     *
+     * @return {Promise} The cname resolution
+     */
+    static async resolveCname(url) {
+        url = ParsedUrl.parse(url)
+        if (url.hostname in cache) {
+            return cache[url.hostname]
+        }
+        if (url.protocol.startsWith("chrome-extension")) {
             return undefined
         }
+        try {
+            let cname = await dns.resolveCname(url.hostname)
+            cache[url.hostname] = cname
+        } catch (e) {
+            if (e.message && !(
+                e.message.includes("ENODATA") ||
+                e.message.includes("ENOTFOUND"))) {
+                console.log(e)
+                return undefined
+            }
+        }
+        return cache[url.hostname]
     }
-    return cache[url.hostname]
+
+    /**
+     * Determine if a given record is in the list of records.
+     * @param {list} cnameRecords - list of cname record objects.
+     * @param {Object} record - a cname record object.
+     * @returns {bool} True if record is contained in the list
+     */
+    static containsCnameRecord(cnameRecords, record) {
+        for (let cReq of cnameRecords) {
+            if (cReq.original === record.original && cReq.resolved === record.resolved) {
+                return true
+            }
+        }
+        return false
+    }
+
+    /**
+     * Create a CNAME record from a Request
+     * @param {Object} request - a Record object.
+     * @returns {Object} a cname object.
+     */
+    static createCnameRecord(request) {
+        return {
+            "original": request.originalSubdomain,
+            "resolved": request.data.subdomain + "." + request.data.domain
+        }
+    }
 }
 
-module.exports = resolveCname
+module.exports = CNAME

--- a/src/trackers/helpers/cname.js
+++ b/src/trackers/helpers/cname.js
@@ -27,7 +27,7 @@ async function resolveCname(url) {
     } catch (e) {
         if (e.message && !(
             e.message.includes("ENODATA") ||
-            e.message.includes("chrome-extension"))) {
+            e.message.includes("ENOTFOUND"))) {
             console.log(e)
             return undefined
         }

--- a/src/trackers/helpers/parseUrl.js
+++ b/src/trackers/helpers/parseUrl.js
@@ -20,7 +20,32 @@ class URL {
 
         this.hostname = tldObj.hostname || tldsObj.host
         this.subdomain = tldObj.subdomain || tldsObj.subdomain
-        this.path = new urlParse.URL(url).pathname
+        const urlData = URL.parse(url)
+
+        this.path = urlData.pathname
+    }
+
+    /*
+     * Format and parse the URL. In cases where the scheme is missing
+     * attempt to guess it.
+     * @param {string} url - url to parse
+     *
+     * @return {urlParse.URL} The parsed URL
+     */
+    static parse(url) {
+        let urlData
+        try {
+            urlData = new urlParse.URL(url)
+        } catch (e) {
+            if (e instanceof TypeError) {
+                urlData = new urlParse.URL("http://" + url)
+            }
+            else {
+                console.log(`error for ${url}`)
+                throw e
+            }
+        }
+        return urlData
     }
 
 }

--- a/src/trackers/process-crawl.js
+++ b/src/trackers/process-crawl.js
@@ -30,10 +30,13 @@ async function processSite(siteName) {
 
     const site = new Site(siteData)
 
+    let requestProcesses = []
     for (let request of siteData.data.requests) {
-        await site.processRequest(request)
+        requestProcesses.push(site.processRequest(request))
         crawl.stats.requests++
     }
+
+    await Promise.allSettled(requestProcesses);
 
     // update crawl level domain prevalence, entity prevalence, and fingerprinting
     crawl.processSite(site)

--- a/src/trackers/process-crawl.js
+++ b/src/trackers/process-crawl.js
@@ -6,7 +6,6 @@ const Progress = require('progress')
 const sharedData = require('./helpers/sharedData.js')
 const crawl = require('./classes/crawl.js')
 const Site = require('./classes/site.js')
-const resolveCname = require('./helpers/cname.js')
 
 console.log(`Reading crawl from: ${sharedData.config.crawlerDataLoc}`)
 
@@ -14,7 +13,6 @@ console.log(`Reading crawl from: ${sharedData.config.crawlerDataLoc}`)
 let siteFileList = fs.readdirSync(sharedData.config.crawlerDataLoc)
 
 const bar = new Progress('Process crawl [:bar] :percent', {width: 40, total: siteFileList.length})
-const parallellism = 100
 
 // Process a single site crawler file. This will look through each request in the file
 // and update the corresponding entry in the global commonRequests object with new data
@@ -53,7 +51,6 @@ async function processCrawl(fileList) {
         }
         await Promise.allSettled(sites)
     }
-    
     crawl.finalizeRequests()
     crawl.writeSummaries()
     console.log(`${chalk.blue(crawl.stats.sites)} sites processed\n${chalk.blue(crawl.stats.requests)} requests processed\n${chalk.blue(crawl.stats.requestsSkipped)} requests skipped`)


### PR DESCRIPTION
Add the ability for the detector to resolve first party CNAME's. If a site is using a DNS CNAME entry to cloak a redirect to a third party, this will gather and save that data, along with the original subdomain.

It will ignore sites that are most likely to be fully hosted on a CDN, such as a top level domain or a www subdomain.