### PR TITLE
catch invalid URLs

### DIFF
--- a/src/trackers/helpers/parseUrl.js
+++ b/src/trackers/helpers/parseUrl.js
@@ -20,7 +20,11 @@ class URL {
 
         this.hostname = tldObj.hostname || tldsObj.host
         this.subdomain = tldObj.subdomain || tldsObj.subdomain
-        this.path = new urlParse.URL(url).pathname
+        try {
+            this.path = new urlParse.URL(url).pathname
+        } catch(e) {
+            console.warn(`\nSkipping unparsable url: ${url}`)
+        }
     }
 
 }


### PR DESCRIPTION
Invalid URLs currently throw an unhandled exception, seems bad