### PR TITLE
Build region list in domain files

### DIFF
--- a/config.json
+++ b/config.json
@@ -4,10 +4,7 @@
     "crawlerDataLoc": "path to your 3rd party request directory",
     "performanceDataLoc": "path to your 3rd party performance directory",
     "flags": {
-        "addSurrogates": false,
-        "regionMap": {
-            
-        }
+        "addSurrogates": false
     },
     "keepFirstParty": false,
     "treatCnameAsFirstParty": false,

--- a/config.json
+++ b/config.json
@@ -4,6 +4,9 @@
     "crawlerDataLoc": "path to your 3rd party request directory",
     "performanceDataLoc": "path to your 3rd party performance directory",
     "flags": {
-        "addSurrogates": false
+        "addSurrogates": false,
+        "regionMap": {
+            
+        }
     }
 }

--- a/src/trackers/build-trackers.js
+++ b/src/trackers/build-trackers.js
@@ -6,8 +6,7 @@ const Progress = require('progress')
 
 const newData = JSON.parse(fs.readFileSync(`${sharedData.config.trackerDataLoc}/commonRequests.json`, 'utf8'))
 const crawlMetadata = JSON.parse(fs.readFileSync(`${sharedData.config.crawlerDataLoc}/metadata.json`, 'utf8'))
-const regionMap = sharedData.config.flags.regionMap || {}
-const countryCode = regionMap[crawlMetadata.config.proxyHost] || 'US'
+const countryCode = crawlMetadata.config.regionCode || 'US'
 const crawledSiteTotal = newData.stats.sites
 const summary = {trackers: 0, entities: []}
 
@@ -66,7 +65,11 @@ console.log(`Found ${summary.trackers} ${chalk.green("trackers")}`)
 console.log(`Found ${summary.entities.length} ${chalk.green("entities")}`)
 console.log(chalk.green("Done"))
 
-fs.writeFileSync(`${sharedData.config.trackerDataLoc}/build-data/generated/releasestats.txt`, `${summary.trackers} domains\n${summary.entities.length} entities`)
+if (!fs.existsSync(`${sharedData.config.trackerDataLoc}/build-data/generated/${countryCode}`)) {
+    fs.mkdirSync(`${sharedData.config.trackerDataLoc}/build-data/generated/${countryCode}`)
+}
+
+fs.writeFileSync(`${sharedData.config.trackerDataLoc}/build-data/generated/${countryCode}/releasestats.txt`, `${summary.trackers} domains\n${summary.entities.length} entities`)
 
 function log (msg) {
     if (sharedData.config.verbose) {

--- a/src/trackers/classes/crawl.js
+++ b/src/trackers/classes/crawl.js
@@ -142,14 +142,13 @@ function _getEntitySummaries (crawl) {
 }
 
 function _writeSummaries (crawl) {
-
     fs.writeFileSync(`${shared.config.trackerDataLoc}/build-data/generated/domain_summary.json`, JSON.stringify(_getDomainSummaries(crawl), null, 4))
 
     fs.writeFileSync(`${shared.config.trackerDataLoc}/commonRequests.json`, JSON.stringify({stats: crawl.stats, requests: crawl.commonRequests}, null, 4))
 
     _getEntitySummaries(crawl)
 
-    fs.writeFileSync(`${shared.config.trackerDataLoc}/build-data/generated//entity_prevalence.json`, JSON.stringify(crawl.entityPrevalence, null, 4))
+    fs.writeFileSync(`${shared.config.trackerDataLoc}/build-data/generated/entity_prevalence.json`, JSON.stringify(crawl.entityPrevalence, null, 4))
 
     // write entity prevalence csv
     let csv = []

--- a/src/trackers/classes/tracker.js
+++ b/src/trackers/classes/tracker.js
@@ -9,6 +9,7 @@ class Tracker {
         let entity = _getEntity(this.domain)
         this.owner = {name: entity.name, displayName: entity.displayName || entity.name} || {}
         this.source = ['DuckDuckGo']
+        this.regions = []
         
         const prevalence = _getPrevalence(this.domain)
         this.prevalence = +prevalence.toPrecision(3)
@@ -55,6 +56,12 @@ class Tracker {
     addSurrogates () {
         const trackerSurrogates = _getSurrogates(this.domain)
         if (trackerSurrogates) {this.surrogates = trackerSurrogates}
+    }
+
+    addRegion (countryCode) {
+        if (!this.regions.includes(countryCode)) {
+            this.regions.push(countryCode)
+        }
     }
 }
 

--- a/src/trackers/classes/tracker.js
+++ b/src/trackers/classes/tracker.js
@@ -10,7 +10,6 @@ class Tracker {
         let entity = _getEntity(this.domain)
         this.owner = {name: entity.name, displayName: entity.displayName || entity.name} || {}
         this.source = ['DuckDuckGo']
-        this.regions = []
         
         const prevalence = _getPrevalence(this.domain)
         this.prevalence = +prevalence.toPrecision(3)
@@ -67,9 +66,7 @@ class Tracker {
     }
 
     addRegion (countryCode) {
-        if (!this.regions.includes(countryCode)) {
-            this.regions.push(countryCode)
-        }
+        this.source = [`DuckDuckGo-${countryCode}`]
     }
 }
 


### PR DESCRIPTION
Tag domain files with the region if found in the config.

**How it works**

* Tracker-Radar-Collector has been updated to write the proxy host used to the `metadata.json` file
* In `config.json` we'll add a map under the `flags` section that has `proxyHost -> region (2 letter country code)`
* ~The detector will look in the tracker-radar for existing domain files and copy the region array (if exists)~
* The detector will write the domain files to a new region specific directory determined by the region map.
* Tag the domain with the region in _this_ crawl (US is assumed when the proxy is missing) by appending the country code to the source property