### PR TITLE
Eslint cleanup + small changes

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,17 +8,12 @@ module.exports = {
         "ecmaVersion": 2018
     },
     "rules": {
-        "max-classes-per-file":"off",
-        "no-console": 'off',
         "accessor-pairs": "error",
-        "array-bracket-newline": "off",
         "array-bracket-spacing": [
             "error",
             "never"
         ],
         "array-callback-return": "error",
-        "array-element-newline": "off",
-        "arrow-body-style": "off",
         "arrow-parens": [
             "error",
             "as-needed"
@@ -44,14 +39,10 @@ module.exports = {
         ],
         "callback-return": "error",
         "camelcase": "error",
-        "class-methods-use-this": "off",
-        "comma-dangle": "off",
-        "comma-spacing": "off",
         "comma-style": [
             "error",
             "last"
         ],
-        "complexity": "off",
         "computed-property-spacing": [
             "error",
             "never"
@@ -82,49 +73,36 @@ module.exports = {
         "function-paren-newline": "error",
         "generator-star-spacing": "error",
         "global-require": "error",
-        "guard-for-in": "off",
         "handle-callback-err": "error",
         "id-blacklist": "error",
-        "id-length": "off",
         "id-match": "error",
         "implicit-arrow-linebreak": [
             "error",
             "beside"
         ],
-        "indent": "off",
-        "indent-legacy": "error",
-        "init-declarations": "off",
+        "indent": "error",
         "jsx-quotes": "error",
         "key-spacing": "error",
-        "keyword-spacing": "off",
-        "line-comment-position": "off",
+        "keyword-spacing": [
+            "error",
+            {"before": true, "after": true}
+        ],
         "linebreak-style": [
             "error",
             "unix"
         ],
-        "lines-around-comment": "off",
         "lines-around-directive": "error",
         "lines-between-class-members": "error",
         "max-depth": "error",
-        "max-len": "off",
-        "max-lines": "off",
-        "max-lines-per-function": "off",
         "max-nested-callbacks": "error",
-        "max-params": "off",
-        "max-statements": "off",
-        "max-statements-per-line": "off",
         "multiline-comment-style": [
             "error",
             "separate-lines"
         ],
         "new-cap": "error",
         "new-parens": "error",
-        "newline-after-var": "off",
-        "newline-before-return": "off",
-        "newline-per-chained-call": "off",
         "no-alert": "error",
         "no-array-constructor": "error",
-        "no-await-in-loop": "off",
         "no-bitwise": "error",
         "no-buffer-constructor": "error",
         "no-caller": "error",
@@ -139,25 +117,19 @@ module.exports = {
                 "allowEmptyCatch": true
             }
         ],
-        "no-empty-function": "off",
         "no-eq-null": "error",
         "no-eval": "error",
         "no-extend-native": "error",
         "no-extra-bind": "error",
         "no-extra-label": "error",
-        "no-extra-parens": "off",
         "no-floating-decimal": "error",
-        "no-implicit-globals": "off",
         "no-implied-eval": "error",
-        "no-inline-comments": "off",
         "no-invalid-this": "error",
         "no-iterator": "error",
         "no-label-var": "error",
         "no-labels": "error",
         "no-lone-blocks": "error",
         "no-lonely-if": "error",
-        "no-loop-func": "off",
-        "no-magic-numbers": "off",
         "no-mixed-operators": [
             "error",
             {
@@ -166,7 +138,6 @@ module.exports = {
         ],
         "no-mixed-requires": "error",
         "no-multi-assign": "error",
-        "no-multi-spaces": "off",
         "no-multi-str": "error",
         "no-multiple-empty-lines": "error",
         "no-native-reassign": "error",
@@ -179,7 +150,6 @@ module.exports = {
         "no-new-wrappers": "error",
         "no-octal-escape": "error",
         "no-path-concat": "error",
-        "no-plusplus": "off",
         "no-process-env": "error",
         "no-proto": "error",
         "no-prototype-builtins": "error",
@@ -204,7 +174,6 @@ module.exports = {
         "no-spaced-func": "error",
         "no-tabs": "error",
         "no-template-curly-in-string": "error",
-        "no-ternary": "off",
         "no-throw-literal": "error",
         "no-trailing-spaces": [
             "error",
@@ -214,8 +183,6 @@ module.exports = {
             }
         ],
         "no-undef-init": "error",
-        "no-undefined": "off",
-        "no-underscore-dangle": "off",
         "no-unmodified-loop-condition": "error",
         "no-unneeded-ternary": "error",
         "no-useless-call": "error",
@@ -235,7 +202,6 @@ module.exports = {
             "never"
         ],
         "object-shorthand": "error",
-        "one-var": "off",
         "one-var-declaration-per-line": [
             "error",
             "initializations"
@@ -245,22 +211,14 @@ module.exports = {
             "always"
         ],
         "operator-linebreak": "error",
-        "padded-blocks": "off",
         "padding-line-between-statements": "error",
         "prefer-arrow-callback": "error",
         "prefer-const": "error",
-        "prefer-destructuring": "off",
         "prefer-numeric-literals": "error",
         "prefer-promise-reject-errors": "error",
         "prefer-rest-params": "error",
         "prefer-spread": "error",
-        "prefer-template": "off",
-        "quote-props": "off",
-        "quotes": "off",
         "radix": "error",
-        "require-await": "off",
-        "require-jsdoc": "off",
-        "require-unicode-regexp": "off",
         "rest-spread-spacing": [
             "error",
             "never"
@@ -278,17 +236,12 @@ module.exports = {
             "last"
         ],
         "sort-imports": "error",
-        "sort-keys": "off",
-        "sort-vars": "off",
         "space-before-blocks": "error",
-        "space-before-function-paren": "off",
         "space-in-parens": [
             "error",
             "never"
         ],
-        "space-infix-ops": "off",
         "space-unary-ops": "error",
-        "spaced-comment": "off",
         "strict": [
             "error",
             "never"
@@ -304,7 +257,6 @@ module.exports = {
             "error",
             "never"
         ],
-        "valid-jsdoc": "off",
         "vars-on-top": "error",
         "wrap-iife": "error",
         "wrap-regex": "error",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,4 +1,5 @@
 {
+  "name": "tracker-radar-detector",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/src/performance/group_data.js
+++ b/src/performance/group_data.js
@@ -180,7 +180,7 @@ main()
  * @property {Array<number>} cpu
  */
 
- /**
+/**
  * @typedef {object} GlobalStats
  * @property {Array<number>} cache
  * @property {Array<number>} time
@@ -189,7 +189,7 @@ main()
  * @property {Array<number>} resourcesPerSite
  */
 
- /**
+/**
   * @typedef {object} Request
   * @property {string} url
   * @property {number} time

--- a/src/performance/helpers/analyzeTrace.js
+++ b/src/performance/helpers/analyzeTrace.js
@@ -48,30 +48,29 @@ async function analyzeTrace(trace, requests) {
 
     let hadExcessiveChromeExtension = false
     const results = Array.from(executionTimings)
-    .map(([url, timingByGroupId]) => {
-        // Add up the totalExecutionTime for all the taskGroups
-        let totalExecutionTimeForURL = 0
-        for (const [groupId, timespanMs] of Object.entries(timingByGroupId)) {
-            timingByGroupId[groupId] = timespanMs
-            totalExecutionTimeForURL += timespanMs
-        }
+        .map(([url, timingByGroupId]) => {
+            // Add up the totalExecutionTime for all the taskGroups
+            let totalExecutionTimeForURL = 0
+            for (const [groupId, timespanMs] of Object.entries(timingByGroupId)) {
+                timingByGroupId[groupId] = timespanMs
+                totalExecutionTimeForURL += timespanMs
+            }
 
-        const scriptingTotal = timingByGroupId[taskGroups.scriptEvaluation.id] || 0
-        const parseCompileTotal = timingByGroupId[taskGroups.scriptParseCompile.id] || 0
+            const scriptingTotal = timingByGroupId[taskGroups.scriptEvaluation.id] || 0
+            const parseCompileTotal = timingByGroupId[taskGroups.scriptParseCompile.id] || 0
 
-        hadExcessiveChromeExtension = hadExcessiveChromeExtension ||
-        (url.startsWith('chrome-extension:') && scriptingTotal > 100)
+            hadExcessiveChromeExtension = hadExcessiveChromeExtension || (url.startsWith('chrome-extension:') && scriptingTotal > 100)
 
-        return {
-            url,
-            total: totalExecutionTimeForURL,
-            // Highlight the JavaScript task costs
-            scripting: scriptingTotal,
-            scriptParseCompile: parseCompileTotal,
-        }
-    })
-    .filter(result => result.total >= thresholdInMs)
-    .sort((a, b) => b.total - a.total)
+            return {
+                url,
+                total: totalExecutionTimeForURL,
+                // Highlight the JavaScript task costs
+                scripting: scriptingTotal,
+                scriptParseCompile: parseCompileTotal,
+            }
+        })
+        .filter(result => result.total >= thresholdInMs)
+        .sort((a, b) => b.total - a.total)
 
     return results
 }

--- a/src/trackers/build-trackers.js
+++ b/src/trackers/build-trackers.js
@@ -61,7 +61,7 @@ for (const key in newData.requests) {
         }
     }
 
-    if(!summary.entities.includes(trackers[fileName].owner.name)) {
+    if (!summary.entities.includes(trackers[fileName].owner.name)) {
         summary.entities.push(trackers[fileName].owner.name)
     }
 

--- a/src/trackers/classes/commonRequest.js
+++ b/src/trackers/classes/commonRequest.js
@@ -54,7 +54,7 @@ function _update (commonReq, newReq, site) {
         commonReq.sites++
         commonReq.apis = _combineApis(commonReq.apis, newReq.apis)
 
-        if(newReq.data.subdomain) {
+        if (newReq.data.subdomain) {
             commonReq.subdomains.add(newReq.data.subdomain)
         }
 

--- a/src/trackers/classes/site.js
+++ b/src/trackers/classes/site.js
@@ -43,7 +43,7 @@ class Site {
 // we will parse and combine those parts to get a single domain
 function _getCookies (siteData) {
     return  siteData.data.cookies.reduce((cookieObj, cookie) => {
-       // some domains will have a leading period we need to remove
+        // some domains will have a leading period we need to remove
         const cookieHost = new ParsedUrl(`http://${cookie.domain.replace(/^\./,'')}`).hostname
         cookieObj[`${cookieHost}${cookie.path}`]
         return cookieObj
@@ -75,7 +75,7 @@ function _analyzeRequest(request, site) {
     }
 
     // The entities found on a site are either tracking or not tracking, e.g., a single tracking request sets the entity as a tracker
-    if(request.owner && typeof site.uniqueEntities[request.owner] !== 'undefined') {
+    if (request.owner && typeof site.uniqueEntities[request.owner] !== 'undefined') {
         if (request.isTracking && site.uniqueEntities[request.owner].tracking === false) {
             site.uniqueEntities[request.owner].tracking = true
         }
@@ -134,9 +134,9 @@ async function _processRequest (requestData, site) {
         !shared.config.treatCnameAsFirstParty &&
         !isRootSite(request, site) &&
         !cnameHelper.isSubdomainExcluded(request.data)
-        ) {
+    ) {
         const cnames = await cnameHelper.resolveCname(request.url)
-        if(cnames) {
+        if (cnames) {
             for (const cname of cnames) {
                 if (!site.isFirstParty(cname)) {
                     // console.log(`Third Party CNAME: ${request.data.subdomain}.${request.data.domain} -> ${cname}`)

--- a/src/trackers/helpers/fingerprints.js
+++ b/src/trackers/helpers/fingerprints.js
@@ -23,7 +23,7 @@ function getFingerprintWeights (crawl) {
     let maxWeight = 0
     const setMaxWeight = []
 
-    for(const [api, apiScores] of Object.entries(crawl.fpWeights.apis)) {
+    for (const [api, apiScores] of Object.entries(crawl.fpWeights.apis)) {
         const trackingWt = apiScores.tracking / crawl.fpWeights.scripts.tracking
         const nontrackingWt = apiScores.nontracking / crawl.fpWeights.scripts.nontracking
 

--- a/src/trackers/helpers/getPerformance.js
+++ b/src/trackers/helpers/getPerformance.js
@@ -6,7 +6,7 @@ function getPerformance (domain, perfDirPath) {
     
     if (fs.existsSync(filePath)) {
         performance = JSON.parse(fs.readFileSync(filePath, 'utf8'))
-    } else{
+    } else {
         return
     }
 

--- a/src/trackers/helpers/parseUrl.js
+++ b/src/trackers/helpers/parseUrl.js
@@ -21,7 +21,7 @@ class URL {
         try {
             const urlData = URL.parse(url)
             this.path = urlData.pathname
-        } catch(e) {
+        } catch (e) {
             console.warn(`\nSkipping unparsable url: ${url}`)
         }
     }


### PR DESCRIPTION
1. We had bunch of rules set to "off" that are off by default (they have no ☑️ on https://eslint.org/docs/rules/), so I removed them.
2. We were using legacy version of indentation check ("indent-legacy") so I upgraded us to the new one ("indent")
3. Jason was demanding that eslint checks make sure that there is space before and after a keyword so I added that