### PR TITLE
Show first-party cookie statistics in tracker-radar

### DIFF
--- a/src/trackers/classes/commonRequest.js
+++ b/src/trackers/classes/commonRequest.js
@@ -146,6 +146,9 @@ function _finalize (request, totalSites) {
         delete cookie.values
         delete cookie.pages
     })
+    Object.keys(request.firstPartyCookiesSent).forEach(cookieName => {
+        request.firstPartyCookiesSent[cookieName] /= totalSites
+    })
     
     request.subdomains = [...request.subdomains]
 }

--- a/src/trackers/classes/commonRequest.js
+++ b/src/trackers/classes/commonRequest.js
@@ -26,6 +26,8 @@ class CommonRequest {
         this.cnames = request.wasCNAME ? [cname.createCnameRecord(request)] : []
         this.responseHashes = []
 
+        this.firstPartyCookies = {}
+
         this.nameservers = request.nameservers
     }
 

--- a/src/trackers/classes/commonRequest.js
+++ b/src/trackers/classes/commonRequest.js
@@ -27,7 +27,8 @@ class CommonRequest {
         this.responseHashes = []
 
         this.firstPartyCookies = {}
-        this._processFirstPartyCookiesForRequest(request, site)
+        this.firstPartyCookiesSent = {}
+        this._processFirstPartyCookiesForRequest(request)
 
         this.nameservers = request.nameservers
     }
@@ -40,7 +41,7 @@ class CommonRequest {
         _finalize(this, totalSites)
     }
 
-    _processFirstPartyCookiesForRequest(request, site) {
+    _processFirstPartyCookiesForRequest(request) {
         request.firstPartyCookies.forEach(cookie => {
             if (!this.firstPartyCookies[cookie.name]) {
                 this.firstPartyCookies[cookie.name] = {
@@ -55,6 +56,12 @@ class CommonRequest {
             cookieStats.ttl.push(cookie.ttl)
             cookieStats.lengthSum += cookie.value.length
             cookieStats.values.add(cookie.value)
+        })
+        request.firstPartyCookiesSent.forEach(cookie => {
+            if (!this.firstPartyCookiesSent[cookie.name]) {
+                this.firstPartyCookiesSent[cookie.name] = 0
+            }
+            this.firstPartyCookiesSent[cookie.name] += 1
         })
     }
 }

--- a/src/trackers/classes/request.js
+++ b/src/trackers/classes/request.js
@@ -1,7 +1,7 @@
 const shared = require('./../helpers/sharedData.js')
 const URL = require('./../helpers/url.js')
 const getOwner = require('./../helpers/getOwner.js')
-const {isFirstPartyCookie} = require('./../helpers/cookies')
+const {isFirstPartyCookie,isCookieValueInUrl} = require('./../helpers/cookies')
 
 const COOKIE_LENGTH_CUTOFF = 5
 
@@ -26,12 +26,9 @@ class Request {
         this.firstPartyCookiesSent = site.documentCookies
             .filter(cookie => {
                 // only consider cookies 6 or more characters long
-                if (cookie.value && cookie.value.length > COOKIE_LENGTH_CUTOFF) {
-                    // for longer cookie values, exclude the first 6 characters (GA cookies only send the suffix)
-                    const cookieSuffix = cookie.value.length > 10 ? cookie.value.slice(6) : cookie.value
-                    return this.url.indexOf(cookieSuffix) !== -1
-                }
-                return false
+                return cookie.value &&
+                    cookie.value.length > COOKIE_LENGTH_CUTOFF &&
+                    isCookieValueInUrl(cookie, ParsedUrl.parse(reqData.url)) // TODO fix with url parsing update
             })
     }
 

--- a/src/trackers/classes/request.js
+++ b/src/trackers/classes/request.js
@@ -18,6 +18,16 @@ class Request {
         this.nameservers = []
         this.firstPartyCookies = site.documentCookies
             .filter(cookie => cookie.source === reqData.url && cookie.domain.endsWith(site.domain))
+        this.firstPartyCookiesSent = site.documentCookies
+            .filter(cookie => {
+                // only consider cookies 5 or more characters long
+                if (cookie.value && cookie.value.length > 5) {
+                    // for longer cookie values, exclude the first 6 characters (GA cookies only send the suffix)
+                    const cookieSuffix = cookie.value.length > 10 ? cookie.value.slice(6) : cookie.value
+                    return this.url.indexOf(cookieSuffix) !== -1
+                }
+                return false
+            })
     }
 
     /**

--- a/src/trackers/classes/request.js
+++ b/src/trackers/classes/request.js
@@ -16,6 +16,8 @@ class Request {
         this.originalSubdomain = undefined
         this.responseHash = reqData.responseBodyHash
         this.nameservers = []
+        this.firstPartyCookies = site.documentCookies
+            .filter(cookie => cookie.source === reqData.url && cookie.domain.endsWith(site.domain))
     }
 
     /**

--- a/src/trackers/classes/request.js
+++ b/src/trackers/classes/request.js
@@ -22,7 +22,7 @@ class Request {
             .filter(cookie => cookie.source === reqData.url && (!cookie.domain || cookie.domain.endsWith(site.domain)) && cookie.value && cookie.value.length > COOKIE_LENGTH_CUTOFF)
         this.firstPartyCookiesSent = site.documentCookies
             .filter(cookie => {
-                // only consider cookies 5 or more characters long
+                // only consider cookies 6 or more characters long
                 if (cookie.value && cookie.value.length > COOKIE_LENGTH_CUTOFF) {
                     // for longer cookie values, exclude the first 6 characters (GA cookies only send the suffix)
                     const cookieSuffix = cookie.value.length > 10 ? cookie.value.slice(6) : cookie.value

--- a/src/trackers/classes/request.js
+++ b/src/trackers/classes/request.js
@@ -21,7 +21,7 @@ class Request {
         this.nameservers = []
         this.firstPartyCookies = site.documentCookies
             .filter(cookie => cookie.source === reqData.url && // cookie source is this request
-                cookie.value && cookie.value.length > COOKIE_LENGTH_CUTOFF && // cookie has a truthy value longer than 5 characters
+                cookie.value && // cookie has a truthy value
                 isFirstPartyCookie(cookie.domain, site.domain)) // cookie was set on the first party origin
         this.firstPartyCookiesSent = site.documentCookies
             .filter(cookie => {

--- a/src/trackers/classes/request.js
+++ b/src/trackers/classes/request.js
@@ -28,7 +28,7 @@ class Request {
                 // only consider cookies 6 or more characters long
                 return cookie.value &&
                     cookie.value.length > COOKIE_LENGTH_CUTOFF &&
-                    isCookieValueInUrl(cookie, ParsedUrl.parse(reqData.url)) // TODO fix with url parsing update
+                    isCookieValueInUrl(cookie, new URL(reqData.url))
             })
     }
 

--- a/src/trackers/classes/request.js
+++ b/src/trackers/classes/request.js
@@ -1,6 +1,7 @@
 const shared = require('./../helpers/sharedData.js')
 const URL = require('./../helpers/url.js')
 const getOwner = require('./../helpers/getOwner.js')
+const {isFirstPartyCookie} = require('./../helpers/cookies')
 
 const COOKIE_LENGTH_CUTOFF = 5
 
@@ -19,7 +20,9 @@ class Request {
         this.responseHash = reqData.responseBodyHash
         this.nameservers = []
         this.firstPartyCookies = site.documentCookies
-            .filter(cookie => cookie.source === reqData.url && (!cookie.domain || cookie.domain.endsWith(site.domain)) && cookie.value && cookie.value.length > COOKIE_LENGTH_CUTOFF)
+            .filter(cookie => cookie.source === reqData.url && // cookie source is this request
+                cookie.value && cookie.value.length > COOKIE_LENGTH_CUTOFF && // cookie has a truthy value longer than 5 characters
+                isFirstPartyCookie(cookie.domain, site.domain)) // cookie was set on the first party origin
         this.firstPartyCookiesSent = site.documentCookies
             .filter(cookie => {
                 // only consider cookies 6 or more characters long
@@ -61,7 +64,6 @@ function _setsCookies (req) {
         return true
     }
     return false
-    
 }
 
 module.exports = Request

--- a/src/trackers/classes/request.js
+++ b/src/trackers/classes/request.js
@@ -2,6 +2,8 @@ const shared = require('./../helpers/sharedData.js')
 const URL = require('./../helpers/url.js')
 const getOwner = require('./../helpers/getOwner.js')
 
+const COOKIE_LENGTH_CUTOFF = 5
+
 class Request {
     constructor (reqData, site) {
         this.site = site
@@ -17,11 +19,11 @@ class Request {
         this.responseHash = reqData.responseBodyHash
         this.nameservers = []
         this.firstPartyCookies = site.documentCookies
-            .filter(cookie => cookie.source === reqData.url && cookie.domain.endsWith(site.domain))
+            .filter(cookie => cookie.source === reqData.url && (!cookie.domain || cookie.domain.endsWith(site.domain)) && cookie.value && cookie.value.length > COOKIE_LENGTH_CUTOFF)
         this.firstPartyCookiesSent = site.documentCookies
             .filter(cookie => {
                 // only consider cookies 5 or more characters long
-                if (cookie.value && cookie.value.length > 5) {
+                if (cookie.value && cookie.value.length > COOKIE_LENGTH_CUTOFF) {
                     // for longer cookie values, exclude the first 6 characters (GA cookies only send the suffix)
                     const cookieSuffix = cookie.value.length > 10 ? cookie.value.slice(6) : cookie.value
                     return this.url.indexOf(cookieSuffix) !== -1

--- a/src/trackers/classes/request.js
+++ b/src/trackers/classes/request.js
@@ -19,11 +19,11 @@ class Request {
         this.originalSubdomain = undefined
         this.responseHash = reqData.responseBodyHash
         this.nameservers = []
-        this.firstPartyCookies = site.documentCookies
+        this.firstPartyCookies = site.thirdPartyJSCookies
             .filter(cookie => cookie.source === reqData.url && // cookie source is this request
                 cookie.value && // cookie has a truthy value
                 isFirstPartyCookie(cookie.domain, site.domain)) // cookie was set on the first party origin
-        this.firstPartyCookiesSent = site.documentCookies
+        this.firstPartyCookiesSent = site.thirdPartyJSCookies
             .filter(cookie => {
                 // only consider cookies 6 or more characters long
                 return cookie.value &&

--- a/src/trackers/classes/rule.js
+++ b/src/trackers/classes/rule.js
@@ -16,6 +16,7 @@ class Rule {
         this.type = newRuleData.type
         this.nameservers = newRuleData.nameservers
         this.firstPartyCookies = newRuleData.firstPartyCookies
+        this.firstPartyCookiesSent = newRuleData.firstPartyCookiesSent
 
         if (sharedData.config.includeExampleSites) {
             this.exampleSites = newRuleData.exampleSites

--- a/src/trackers/classes/rule.js
+++ b/src/trackers/classes/rule.js
@@ -15,6 +15,7 @@ class Rule {
         this.responseHashes = newRuleData.responseHashes
         this.type = newRuleData.type
         this.nameservers = newRuleData.nameservers
+        this.firstPartyCookies = newRuleData.firstPartyCookies
 
         if (sharedData.config.includeExampleSites) {
             this.exampleSites = newRuleData.exampleSites

--- a/src/trackers/classes/site.js
+++ b/src/trackers/classes/site.js
@@ -1,4 +1,4 @@
-const tldts = require('tldts')
+const tldts = require('tldts-experimental')
 
 const Request = require('./request.js')
 const shared = require('./../helpers/sharedData.js')

--- a/src/trackers/classes/site.js
+++ b/src/trackers/classes/site.js
@@ -4,6 +4,8 @@ const URL = require('./../helpers/url.js')
 const cnameHelper = require('./../helpers/cname.js')
 const getOwner = require('./../helpers/getOwner.js')
 
+const {calculateCookieTtl,isSavedCookieSetterCall,parseCookie} = require('../helpers/cookies')
+
 class Site {
     constructor (siteData) {
         this.siteData = siteData
@@ -31,6 +33,11 @@ class Site {
         this.cnameCloaks = {}
 
         this.analyzeRequest = _analyzeRequest.bind(this)
+
+        this.documentCookies = siteData.data.apis.savedCalls.filter(isSavedCookieSetterCall)
+            .map(({source, arguments: args}) => Object.assign({source}, parseCookie(args[0])))
+            .map(cookie => Object.assign(cookie, {ttl: calculateCookieTtl(cookie, siteData.testStarted)}))
+    
     }
 
     async processRequest (requestData) {

--- a/src/trackers/classes/site.js
+++ b/src/trackers/classes/site.js
@@ -36,7 +36,7 @@ class Site {
 
         this.analyzeRequest = _analyzeRequest.bind(this)
 
-        this.documentCookies = Object.values(siteData.data.apis.savedCalls
+        this.thirdPartyJSCookies = Object.values(siteData.data.apis.savedCalls
             .filter(call => {
                 if (!isSavedCookieSetterCall(call) || !call.source.startsWith('http')) {
                     return false

--- a/src/trackers/classes/site.js
+++ b/src/trackers/classes/site.js
@@ -35,6 +35,14 @@ class Site {
         this.analyzeRequest = _analyzeRequest.bind(this)
 
         this.documentCookies = siteData.data.apis.savedCalls.filter(isSavedCookieSetterCall)
+        this.documentCookies = siteData.data.apis.savedCalls
+            .filter(call => {
+                if (!isSavedCookieSetterCall(call) || !call.source.startsWith('http')) {
+                    return false
+                }
+                const sourceHost = tldts.parse(call.source)
+                return sourceHost.isIp ? sourceHost.host !== this.host : sourceHost.domain !== this.domain
+            })
             .map(({source, arguments: args}) => Object.assign({source}, parseCookie(args[0])))
             .map(cookie => Object.assign(cookie, {ttl: calculateCookieTtl(cookie, siteData.testStarted)}))
     

--- a/src/trackers/helpers/cookies.js
+++ b/src/trackers/helpers/cookies.js
@@ -58,9 +58,33 @@ function isFirstPartyCookie(cookieDomain, siteGeneralDomain) {
     return siteGeneralDomain === cleanCookieDomain || siteGeneralDomain === getDomain(cleanCookieDomain)
 }
 
+/**
+ * Set of handlers for apply custom search logic for specific cookies.
+ * e.g. for _ga cookies only the suffix is generally sent, so this handler will only use this part
+ * when searching for the cookie in a URL.
+ */
+const cookieHandlers = [{
+    canHandle: ({name}) => name === '_ga',
+    getValueSearchString: ({value}) => value.slice(6),
+}, {
+    canHandle: () => true,
+    getValueSearchString: ({value}) => value,
+}]
+/**
+ * Look for the value of a cookie in a URL. Returns true iff it is found, false otherwise.
+ * @param {*} cookie Parsed cookie
+ * @param {URL} url to check against
+ */
+function isCookieValueInUrl(cookie, url) {
+    const handler = cookieHandlers.find(h => h.canHandle(cookie))
+    const cookieValue = handler.getValueSearchString(cookie)
+    return url.pathname.indexOf(cookieValue) !== -1 || url.search.indexOf(cookieValue) !== -1
+}
+
 module.exports = {
     isSavedCookieSetterCall,
     parseCookie,
     calculateCookieTtl,
     isFirstPartyCookie,
+    isCookieValueInUrl,
 }

--- a/src/trackers/helpers/cookies.js
+++ b/src/trackers/helpers/cookies.js
@@ -1,0 +1,47 @@
+
+/**
+ * Returns true iff this savedCall is a valid call to document.cookie
+ * @param {Object} savedCall data
+ */
+function isSavedCookieSetterCall({description, arguments: args}) {
+    return description === 'Document.cookie setter' &&
+                typeof args !== 'boolean' &&
+                args.length > 0 &&
+                typeof args[0] === 'string'
+}
+
+/**
+ * Parse a cookie string as passed to document.cookie setter and extract its attributes
+ * @param {string} cookieString 
+ */
+function parseCookie(cookieString) {
+    const parsed = cookieString.split(';').map(pair => pair.split('=', 2).map(s => s.trim()))
+    return parsed.reduce((info, [k, v], i) => {
+        if (i === 0) {
+            info.name = k
+            info.value = v
+        } else if (k) {
+            info[k.toLowerCase()] = v
+        }
+        return info
+    }, {})
+}
+
+/**
+ * Calculate the cookie time to live, given the timestamp when the cookie was set.
+ * @param {Object} cookie - parsed cookie
+ * @param {Number} setAtTs - timestamp in ms when the cookie was set
+ * @returns TTL of this cookie in seconds from setAtTs.
+ */
+function calculateCookieTtl(cookie, setAtTs) {
+    if (cookie['max-age']) {
+        return parseInt(cookie['max-age'], 10)
+    }
+    return Math.floor((new Date(cookie.expires).getTime() - setAtTs) / 1000)
+}
+
+module.exports = {
+    isSavedCookieSetterCall,
+    parseCookie,
+    calculateCookieTtl,
+}

--- a/src/trackers/helpers/cookies.js
+++ b/src/trackers/helpers/cookies.js
@@ -1,4 +1,4 @@
-const {getDomain} = require('tldts')
+const {getDomain} = require('tldts-experimental')
 
 /**
  * Returns true iff this savedCall is a valid call to document.cookie

--- a/src/trackers/helpers/cookies.js
+++ b/src/trackers/helpers/cookies.js
@@ -1,3 +1,4 @@
+const {getDomain} = require('tldts')
 
 /**
  * Returns true iff this savedCall is a valid call to document.cookie
@@ -40,8 +41,26 @@ function calculateCookieTtl(cookie, setAtTs) {
     return Math.floor((new Date(cookie.expires).getTime() - setAtTs) / 1000)
 }
 
+/**
+ * Given a cookie set on a site, returns true if this cookie was set on the 1st party
+ * @param {string} cookieDomain domain attribute of the cookie
+ * @param {string} siteGeneralDomain eTLD+1 of the 1st party website
+ * @returns {boolean}
+ */
+function isFirstPartyCookie(cookieDomain, siteGeneralDomain) {
+    // if the cookie has no domain attribute it is by default set on the host of the current
+    // document URL
+    if (!cookieDomain) {
+        return true
+    }
+    // a leading '.' in the domain is ignored in the current spec
+    const cleanCookieDomain = cookieDomain.startsWith('.') ? cookieDomain.slice(1) : cookieDomain
+    return siteGeneralDomain === cleanCookieDomain || siteGeneralDomain === getDomain(cleanCookieDomain)
+}
+
 module.exports = {
     isSavedCookieSetterCall,
     parseCookie,
     calculateCookieTtl,
+    isFirstPartyCookie,
 }

--- a/test/build-tracker.test.js
+++ b/test/build-tracker.test.js
@@ -18,6 +18,14 @@ const commonRequestData1 = {
     sites: 2,
     subdomains: new Set(['dummy']),
     type: "XHR",
+    firstPartyCookies: {
+        "_uid": {
+            prevalence: 0.8,
+            length: 14,
+            uniqueness: 1,
+            expiry: 2628000,
+        }
+    }
 }
 const commonRequestData2 = {
     apis: {},
@@ -78,5 +86,17 @@ describe('Tracker', () => {
         assert.strictEqual(resource.type, 'XHR')
         assert.strictEqual(resource.prevalence, 1)
         assert.strictEqual(resource.sites, 2)
+    })
+
+    it('resource has firstPartyCookies stats', () => {
+        const resource = tracker.resources[0]
+        assert.deepStrictEqual(resource.firstPartyCookies, {
+            "_uid": {
+                prevalence: 0.8,
+                length: 14,
+                uniqueness: 1,
+                expiry: 2628000,
+            }
+        })
     })
 })

--- a/test/build-tracker.test.js
+++ b/test/build-tracker.test.js
@@ -25,6 +25,9 @@ const commonRequestData1 = {
             uniqueness: 1,
             expiry: 2628000,
         }
+    },
+    firstPartyCookiesSent: {
+        "_ga": 0.5,
     }
 }
 const commonRequestData2 = {
@@ -97,6 +100,13 @@ describe('Tracker', () => {
                 uniqueness: 1,
                 expiry: 2628000,
             }
+        })
+    })
+
+    it('resource has firstPartyCookiesSent stats', () => {
+        const resource = tracker.resources[0]
+        assert.deepStrictEqual(resource.firstPartyCookiesSent, {
+            "_ga": 0.5
         })
     })
 })

--- a/test/fixtures/example.com.json
+++ b/test/fixtures/example.com.json
@@ -27,6 +27,13 @@
           "arguments": [
             "_ga=GA1.2.2073038129.1608010879; path=/; expires=Thu, 15 Dec 2022 05:41:27 GMT; domain=example.com;"
           ]
+        },
+        {
+          "source": "https://test.example.com/",
+          "description": "Document.cookie setter",
+          "arguments": [
+            "test=helloworld; path=/; expires=Thu, 15 Dec 2022 05:41:27 GMT; domain=example.com;"
+          ]
         }
       ]
     },

--- a/test/fixtures/example.com.json
+++ b/test/fixtures/example.com.json
@@ -212,7 +212,7 @@
         "time": 0.01091800071299076
       },
       {
-        "url": "https://dummy.tracker.com/collect",
+        "url": "https://dummy.tracker.com/collect?gaid=2073038129.1608010879",
         "method": "GET",
         "type": "XHR",
         "status": 202,

--- a/test/parse-cookie.test.js
+++ b/test/parse-cookie.test.js
@@ -1,7 +1,7 @@
 const assert = require('assert')
 const {describe, it} = require('mocha')
 
-const {parseCookie,calculateCookieTtl} = require('../src/trackers/helpers/cookies')
+const {parseCookie,calculateCookieTtl,isFirstPartyCookie} = require('../src/trackers/helpers/cookies')
 
 const validCookies = [
     ['csm-hit=tb:s-ZP1GK7T6BAHZ943S3WS9|1607976278934&t:1607976279951&adb:adblk_no;expires=Mon, 29 Nov 2021 20:04:39 GMT;path=/', {
@@ -44,6 +44,22 @@ describe('calculateCookieTtl', () => {
     validCookies.forEach(([cookieString, cookie, ttl]) => {
         it(`Determines TTL correctly for ${cookieString}`, () => {
             assert.strictEqual(calculateCookieTtl(cookie, startTs), ttl)
+        })
+    })
+})
+
+describe('isFirstPartyCookie', () => {
+    const firstPartyExamples = [
+        [undefined, 'example.com', true],
+        ['example.com', 'example.com', true],
+        ['.example.com', 'example.com', true],
+        ['www.example.com', 'example.com', true],
+        ['.co.uk', 'example.co.uk', false],
+        ['.github.com', 'hub.com', false],
+    ]
+    firstPartyExamples.forEach(([cookieDomain, siteDomain, expected]) => {
+        it(`isFirstPartyCookie(${cookieDomain}, ${siteDomain}) === ${expected}`, () => {
+            assert.strictEqual(isFirstPartyCookie(cookieDomain, siteDomain), expected)
         })
     })
 })

--- a/test/parse-cookie.test.js
+++ b/test/parse-cookie.test.js
@@ -1,0 +1,35 @@
+const assert = require('assert')
+const {describe, it} = require('mocha')
+
+const {parseCookie} = require('../src/trackers/helpers/cookies')
+
+const validCookies = [
+    ['csm-hit=tb:s-ZP1GK7T6BAHZ943S3WS9|1607976278934&t:1607976279951&adb:adblk_no;expires=Mon, 29 Nov 2021 20:04:39 GMT;path=/', {
+        name: 'csm-hit',
+        value: 'tb:s-ZP1GK7T6BAHZ943S3WS9|1607976278934&t:1607976279951&adb:adblk_no',
+        path: '/',
+        expires: 'Mon, 29 Nov 2021 20:04:39 GMT'
+    }],
+    ['ajs_anonymous_id=%227ad765cd-b323-44d6-9a97-fedf36d907ab%22; path=/; domain=.cnn.com; expires=Wed, 15 Dec 2021 04:30:27 GMT; SameSite=Lax', {
+        domain: '.cnn.com',
+        expires: 'Wed, 15 Dec 2021 04:30:27 GMT',
+        name: 'ajs_anonymous_id',
+        path: '/',
+        samesite: 'Lax',
+        value: '%227ad765cd-b323-44d6-9a97-fedf36d907ab%22'
+    }],
+    ['foo=bar;path=/;max-age=3600', {
+        name: 'foo',
+        value: 'bar',
+        path: '/',
+        'max-age': '3600',
+    }]
+]
+
+describe('parseCookie', () => {
+    validCookies.forEach(([cookieString, expected]) => {
+        it(`Parses ${cookieString} correctly`, () => {
+            assert.deepStrictEqual(parseCookie(cookieString), expected)
+        })
+    })
+})

--- a/test/parse-cookie.test.js
+++ b/test/parse-cookie.test.js
@@ -1,7 +1,7 @@
 const assert = require('assert')
 const {describe, it} = require('mocha')
 
-const {parseCookie} = require('../src/trackers/helpers/cookies')
+const {parseCookie,calculateCookieTtl} = require('../src/trackers/helpers/cookies')
 
 const validCookies = [
     ['csm-hit=tb:s-ZP1GK7T6BAHZ943S3WS9|1607976278934&t:1607976279951&adb:adblk_no;expires=Mon, 29 Nov 2021 20:04:39 GMT;path=/', {
@@ -9,7 +9,7 @@ const validCookies = [
         value: 'tb:s-ZP1GK7T6BAHZ943S3WS9|1607976278934&t:1607976279951&adb:adblk_no',
         path: '/',
         expires: 'Mon, 29 Nov 2021 20:04:39 GMT'
-    }],
+    }, 25935235],
     ['ajs_anonymous_id=%227ad765cd-b323-44d6-9a97-fedf36d907ab%22; path=/; domain=.cnn.com; expires=Wed, 15 Dec 2021 04:30:27 GMT; SameSite=Lax', {
         domain: '.cnn.com',
         expires: 'Wed, 15 Dec 2021 04:30:27 GMT',
@@ -17,19 +17,33 @@ const validCookies = [
         path: '/',
         samesite: 'Lax',
         value: '%227ad765cd-b323-44d6-9a97-fedf36d907ab%22'
-    }],
+    }, 27261583],
     ['foo=bar;path=/;max-age=3600', {
         name: 'foo',
         value: 'bar',
         path: '/',
         'max-age': '3600',
-    }]
+    }, 3600],
+    ['foo=bar;path=/', {
+        name: 'foo',
+        value: 'bar',
+        path: '/',
+    }, NaN]
 ]
 
 describe('parseCookie', () => {
     validCookies.forEach(([cookieString, expected]) => {
         it(`Parses ${cookieString} correctly`, () => {
             assert.deepStrictEqual(parseCookie(cookieString), expected)
+        })
+    })
+})
+
+describe('calculateCookieTtl', () => {
+    const startTs = new Date('2021-02-02T15:50:43.604Z').getTime()
+    validCookies.forEach(([cookieString, cookie, ttl]) => {
+        it(`Determines TTL correctly for ${cookieString}`, () => {
+            assert.strictEqual(calculateCookieTtl(cookie, startTs), ttl)
         })
     })
 })

--- a/test/process-crawl.test.js
+++ b/test/process-crawl.test.js
@@ -115,6 +115,9 @@ describe('Process Crawl', () => {
                 sites: 1,
                 subdomains: ['dummy'],
                 type: "XHR",
+                firstPartyCookiesSent: {
+                    "_ga": 1,
+                }
             })
         })
 

--- a/test/process-crawl.test.js
+++ b/test/process-crawl.test.js
@@ -56,7 +56,7 @@ describe('Process Crawl', () => {
         })
 
         it('extracts document cookies', () => {
-            assert.deepStrictEqual(site.documentCookies, [{
+            assert.deepStrictEqual(site.thirdPartyJSCookies, [{
                 domain: 'example.com',
                 expires: 'Thu, 15 Dec 2022 05:41:27 GMT',
                 name: '_ga',

--- a/test/process-crawl.test.js
+++ b/test/process-crawl.test.js
@@ -54,6 +54,18 @@ describe('Process Crawl', () => {
                 }
             })
         })
+
+        it('extracts document cookies', () => {
+            assert.deepStrictEqual(site.documentCookies, [{
+                domain: 'example.com',
+                expires: 'Thu, 15 Dec 2022 05:41:27 GMT',
+                name: '_ga',
+                path: '/',
+                source: 'https://www.google-analytics.com/analytics.js',
+                value: 'GA1.2.2073038129.1608010879',
+                ttl: 63113410,
+            }])
+        })
     })
 
     describe('crawl', () => {
@@ -80,6 +92,14 @@ describe('Process Crawl', () => {
             assert.strictEqual(crawl.commonRequests['google-analytics.com/analytics.js - Script'].apis['Navigator.prototype.userAgent'], 1)
             assertObjectPartial(crawl.commonRequests['google-analytics.com/analytics.js - Script'], {
                 cookies: 0.5,
+                firstPartyCookies: {
+                    "_ga": {
+                        prevalence: 1,
+                        length: 27,
+                        uniqueness: 1,
+                        expiry: 2628000,
+                    }
+                }
             })
     
             assertObjectPartial(crawl.commonRequests["tracker.com/collect - XHR"], {

--- a/test/process-crawl.test.js
+++ b/test/process-crawl.test.js
@@ -94,10 +94,10 @@ describe('Process Crawl', () => {
                 cookies: 0.5,
                 firstPartyCookies: {
                     "_ga": {
-                        prevalence: 1,
+                        prevalence: 0.5,
                         length: 27,
                         uniqueness: 1,
-                        expiry: 2628000,
+                        ttl: 63113410,
                     }
                 }
             })

--- a/test/process-crawl.test.js
+++ b/test/process-crawl.test.js
@@ -116,7 +116,7 @@ describe('Process Crawl', () => {
                 subdomains: ['dummy'],
                 type: "XHR",
                 firstPartyCookiesSent: {
-                    "_ga": 1,
+                    "_ga": 0.5,
                 }
             })
         })


### PR DESCRIPTION
https://app.asana.com/0/481882893211075/1199637690641235/f

Adds stats on first party cookies set by 3rd party scripts to tracker-radar data. This is added per resource as follows:
```js
"resources": [
    {
      "rule": "google-analytics\\.com\\/analytics\\.js",
      "firstPartyCookies": {
        "_ga": {
          "ttl": 63072001, // median expiry of this cookie, in seconds from set time.
          "length": 26, // mean string length of the cookie value
          "prevalence": 0.23242023108118448, // proportion of sites in the crawl where this cookie was set by this script
          "uniqueness": 1 // number of distinct values seen divided by times set
        },
    ...
```

We also detect when the cookie value was sent in another 3rd party request, and include the frequency of this:
```js
"resources": [
...
   {
      "firstPartyCookiesSent": {
        "_ga": 0.03884765475552835, // proportion of sites in the crawl where the value of this 1st party cookie was sent to this endpoint
        "G_ENABLED_IDPS": 0.0005126635549774275
      },
```

This PR is based on top of #26 so please merge that before merging this one.