### PR TITLE
Strip parameter string from URL path

### DIFF
--- a/src/trackers/helpers/url.js
+++ b/src/trackers/helpers/url.js
@@ -33,6 +33,14 @@ class ParsedURL extends URL {
     get subdomain() {
         return this.domainInfo.subdomain
     }
+
+    /**
+     * Cut any parameter string from the URL path
+     */
+    get path() {
+        const pathname = this.pathname
+        return pathname.split(';')[0]
+    }
 }
 
 module.exports = ParsedURL

--- a/test/fixtures/example.com.json
+++ b/test/fixtures/example.com.json
@@ -219,7 +219,7 @@
         "time": 0.01091800071299076
       },
       {
-        "url": "https://dummy.tracker.com/collect?gaid=2073038129.1608010879",
+        "url": "https://dummy.tracker.com/collect;some=parameterstring?gaid=2073038129.1608010879",
         "method": "GET",
         "type": "XHR",
         "status": 202,


### PR DESCRIPTION
Allows us to properly count URLs which are using parameter strings when aggregating requests.