### PR TITLE
Surrogates mapping file has moved to a different repo.

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,6 +1,7 @@
 {
     "minSites": 2,
     "trackerDataLoc": "path to your Tracker Radar repo",
+    "surrogatesDataLoc": "path to your copy of duckduckgo/tracker-surrogates repo",
     "crawlerDataLoc": "path to your 3rd party request directory",
     "performanceDataLoc": "path to your 3rd party performance directory",
     "crawlId": "",

--- a/src/trackers/helpers/sharedData.js
+++ b/src/trackers/helpers/sharedData.js
@@ -13,7 +13,7 @@ class SharedData {
 
         this.config = cfg
         this.policies = _getJSON(`${build}/static/privacy_policies.json`)
-        this.surrogates = _getJSON(`${build}/static/surrogates.json`)
+        this.surrogates = _getJSON(`${cfg.surrogatesDataLoc}/mapping.json`)
         this.domains = _getJSON(`${build}/generated/domain_summary.json`) || {}
         this.abuseScores = _getJSON(`${build}/generated/api_fingerprint_weights.json`)
         this.categories = _getCategories()


### PR DESCRIPTION
The surrogates mapping file is now here: https://github.com/duckduckgo/tracker-surrogates/blob/main/mapping.json . Adjusted config and code accordingly.