### PR TITLE
Top initiators per domain

### DIFF
--- a/src/trackers/classes/crawl.js
+++ b/src/trackers/classes/crawl.js
@@ -181,18 +181,20 @@ function _getDomainSummaries (crawl) {
         let requests = 0
         let top = []
 
-        Object.keys(crawl.domainInitiators).forEach(init => {
-            requests += crawl.domainInitiators[init]
+        Object.keys(crawl.domainInitiators[domain]).forEach(init => {
+            requests += crawl.domainInitiators[domain][init]
         })
 
         // transform to [{domain: initiator.com, prevalence: 0.1}] where prevalence is calculated for all requests
-        Object.keys(crawl.domainInitiators).forEach(init => {
-            top.push({domain: init, prevalence: crawl.domainInitiators[init] / requests})
+        Object.keys(crawl.domainInitiators[domain]).forEach(init => {
+            top.push({domain: init, prevalence: crawl.domainInitiators[domain][init] / requests})
         })
 
         // sort by prevalence, get top 10
         top = top.sort((a, b) => b.prevalence - a.prevalence)
-        top.length = 10
+        if (top.length > 10) {
+            top.length = 10
+        }
 
         domainSummary[domain].topInitiators = top
     })

--- a/src/trackers/classes/crawl.js
+++ b/src/trackers/classes/crawl.js
@@ -33,6 +33,9 @@ class Crawl {
         // Sites that are CNAME cloaked as first party.
         this.domainCloaks = {}
 
+        // initiators for 3p domain across the whole crawl
+        this.domainInitiators = {}
+
         this.pageMap = {}
 
         // for calculating api fingerprint weights
@@ -81,6 +84,14 @@ function _processSite (crawl, site) {
 
         if (site.uniqueDomains[domain].usesCNAMECloaking) {
             crawl.domainCloaks[domain] ? crawl.domainCloaks[domain]++ : crawl.domainCloaks[domain] = 1
+        }
+
+        if (site.uniqueDomains[domain].initiators) {
+            for (const initiator of Object.keys(site.uniqueDomains[domain].initiators)) {
+                const count = site.uniqueDomains[domain].initiators[initiator]
+                crawl.domainInitiators[domain] = crawl.domainInitiators[domain] || {}
+                crawl.domainInitiators[domain][initiator] ? crawl.domainInitiators[domain][initiator] += count : crawl.domainInitiators[domain][initiator] = count
+            }
         }
     })
 
@@ -163,6 +174,27 @@ function _getDomainSummaries (crawl) {
     // How often does this domain appear cloaked?
     Object.keys(crawl.domainCloaks).forEach(domain => {
         domainSummary[domain].cloaked = crawl.domainCloaks[domain] / crawl.domainPrevalence[domain]
+    })
+
+    // top initiators
+    Object.keys(crawl.domainInitiators).forEach(domain => {
+        let requests = 0
+        let top = []
+
+        Object.keys(crawl.domainInitiators).forEach(init => {
+            requests += crawl.domainInitiators[init]
+        })
+
+        // transform to [{domain: initiator.com, prevalence: 0.1}] where prevalence is calculated for all requests
+        Object.keys(crawl.domainInitiators).forEach(init => {
+            top.push({domain: init, prevalence: crawl.domainInitiators[init] / requests})
+        })
+
+        // sort by prevalence, get top 10
+        top = top.sort((a, b) => b.prevalence - a.prevalence)
+        top.length = 10
+
+        domainSummary[domain].topInitiators = top
     })
 
     return domainSummary

--- a/src/trackers/classes/site.js
+++ b/src/trackers/classes/site.js
@@ -119,6 +119,12 @@ function _analyzeRequest(request, site) {
     if (request.wasCNAME) {
         site.uniqueDomains[request.domain].usesCNAMECloaking = true
     }
+
+    if (request.initiator) {
+        site.uniqueDomains[request.domain].initiators = site.uniqueDomains[request.domain].initiators || {}
+        site.uniqueDomains[request.domain].initiators[request.initiator] = site.uniqueDomains[request.domain].initiators[request.initiator] || 0
+        site.uniqueDomains[request.domain].initiators[request.initiator]++
+    }
 }
 
 /**

--- a/src/trackers/classes/tracker.js
+++ b/src/trackers/classes/tracker.js
@@ -23,6 +23,7 @@ class Tracker {
         this.categories = _getCategories(this.domain) || []
         this.performance = performanceHelper.getPerformance(this.domain, sharedData.config.performanceDataLoc) || {}
         this.cookies = +(_getCookies(this.domain).toPrecision(3))
+        this.topInitiators = sharedData.domains[this.domain].topInitiators
 
         const policy = _getPolicy(this.domain, this.owner)
         

--- a/test/fixtures/example.com.json
+++ b/test/fixtures/example.com.json
@@ -69,6 +69,24 @@
     ],
     "requests": [
       {
+        "url": "https://www.googletagmanager.com/gtm.js?id=GTM-ZZZ",
+        "method": "GET",
+        "type": "Script",
+        "status": 200,
+        "size": 37271,
+        "remoteIPAddress": "142.250.185.72",
+        "responseHeaders": {
+          "access-control-allow-origin": "*",
+          "cache-control": "private, max-age=900",
+          "expires": "Mon, 01 Feb 2021 14:07:14 GMT"
+        },
+        "responseBodyHash": "3ae72ef0d11e614d693f9ead74ee5060de4f92cacd142c8e888a6820ba346151",
+        "initiators": [
+          "https://test.example.com/test/"
+        ],
+        "time": 0.014581999137997627
+      },
+      {
         "url": "https://www.google-analytics.com/analytics.js",
         "method": "GET",
         "type": "Script",
@@ -81,7 +99,7 @@
         },
         "responseBodyHash": "e441c3e2771625ba05630ab464275136a82c99650ee2145ca5aa9853bedeb01b",
         "initiators": [
-          "https://test.example.com/en-US/firefox/"
+          "https://www.googletagmanager.com/gtm.js?id=GTM-ZZZ"
         ],
         "time": 0.016581999137997627
       },
@@ -100,7 +118,8 @@
         },
         "responseBodyHash": "6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b",
         "initiators": [
-          "https://www.google-analytics.com/analytics.js"
+          "https://www.google-analytics.com/analytics.js",
+          "https://www.googletagmanager.com/gtm.js?id=GTM-ZZZ"
         ],
         "time": 0.011511998251080513
       },
@@ -119,7 +138,8 @@
         },
         "responseBodyHash": "8337212354871836e6763a41e615916c89bac5b3f1f0adf60ba43c7c806e1015",
         "initiators": [
-          "https://www.google-analytics.com/analytics.js"
+          "https://www.google-analytics.com/analytics.js",
+          "https://www.googletagmanager.com/gtm.js?id=GTM-ZZZ"
         ],
         "time": 0.01307000033557415
       },
@@ -138,7 +158,8 @@
         },
         "responseBodyHash": "8337212354871836e6763a41e615916c89bac5b3f1f0adf60ba43c7c806e1015",
         "initiators": [
-          "https://www.google-analytics.com/analytics.js"
+          "https://www.google-analytics.com/analytics.js",
+          "https://www.googletagmanager.com/gtm.js?id=GTM-ZZZ"
         ],
         "time": 0.013325000181794167
       },
@@ -157,7 +178,8 @@
         },
         "responseBodyHash": "8337212354871836e6763a41e615916c89bac5b3f1f0adf60ba43c7c806e1015",
         "initiators": [
-          "https://www.google-analytics.com/analytics.js"
+          "https://www.google-analytics.com/analytics.js",
+          "https://www.googletagmanager.com/gtm.js?id=GTM-ZZZ"
         ],
         "time": 0.015500999987125397
       },
@@ -176,7 +198,8 @@
         },
         "responseBodyHash": "8337212354871836e6763a41e615916c89bac5b3f1f0adf60ba43c7c806e1015",
         "initiators": [
-          "https://www.google-analytics.com/analytics.js"
+          "https://www.google-analytics.com/analytics.js",
+          "https://www.googletagmanager.com/gtm.js?id=GTM-ZZZ"
         ],
         "time": 0.011066999286413193
       },
@@ -195,7 +218,8 @@
         },
         "responseBodyHash": "8337212354871836e6763a41e615916c89bac5b3f1f0adf60ba43c7c806e1015",
         "initiators": [
-          "https://www.google-analytics.com/analytics.js"
+          "https://www.google-analytics.com/analytics.js",
+          "https://www.googletagmanager.com/gtm.js?id=GTM-ZZZ"
         ],
         "time": 0.010642999783158302
       },
@@ -214,7 +238,8 @@
         },
         "responseBodyHash": "8337212354871836e6763a41e615916c89bac5b3f1f0adf60ba43c7c806e1015",
         "initiators": [
-          "https://www.google-analytics.com/analytics.js"
+          "https://www.google-analytics.com/analytics.js",
+          "https://www.googletagmanager.com/gtm.js?id=GTM-ZZZ"
         ],
         "time": 0.01091800071299076
       },

--- a/test/process-crawl.test.js
+++ b/test/process-crawl.test.js
@@ -17,6 +17,7 @@ describe('Process Crawl', () => {
 
     let site
     const expectedDomains = [
+        "googletagmanager.com",
         "google-analytics.com",
         "tracker.com"
     ]
@@ -42,6 +43,10 @@ describe('Process Crawl', () => {
 
         it('extracts 3p domains', () => {
             assert.deepStrictEqual(Object.keys(site.uniqueDomains), expectedDomains)
+        })
+
+        it('extracts 3p domain initiators', () => {
+            assert.deepStrictEqual(site.uniqueDomains['google-analytics.com'].initiators, {"googletagmanager.com": 8})
         })
 
         it('extracts 3p entities', () => {
@@ -72,6 +77,7 @@ describe('Process Crawl', () => {
         it('extracts domain prevalence', () => {
             assert.deepStrictEqual(crawl.domainPrevalence, {
                 "google-analytics.com": 1,
+                "googletagmanager.com": 1,
                 "tracker.com": 1,
             })
         })
@@ -84,6 +90,20 @@ describe('Process Crawl', () => {
             assert.deepStrictEqual(crawl.domainCookies, {
                 'google-analytics.com': 1,
                 'tracker.com': 1,
+            })
+        })
+
+        it('extracts domain initiators', () => {
+            assert.deepStrictEqual(crawl.domainInitiators, {
+                'google-analytics.com': {
+                    'googletagmanager.com': 8
+                },
+                'googletagmanager.com': {
+                    'first party': 1
+                },
+                'tracker.com': {
+                    'first party': 1
+                },
             })
         })
 


### PR DESCRIPTION
This change calculates top 10 initiators for given domain. First party (site requesting domain directly) is tagged as 'first party'. Example output:

![top-initiators](https://user-images.githubusercontent.com/985504/199683000-90a5c5a7-b469-4f92-a3b7-d3a0ef9076bd.jpg)

Tested on a small crawl (100 sites), not stress tested on anything big.