### PR TITLE
Fix CNAME '.' prefixing

### DIFF
--- a/src/trackers/classes/site.js
+++ b/src/trackers/classes/site.js
@@ -213,8 +213,8 @@ async function _processRequest (requestData, site) {
                 const cnameUrl = `http://${cname}`
                 if (!site.isFirstParty(cnameUrl)) {
                     // console.log(`Third Party CNAME: ${request.data.subdomain}.${request.data.domain} -> ${cname}`)
-                    const origSubDomain = request.data.subdomain + "." + request.data.domain
-                    site.cnameCloaks[cname] = request.data.subdomain + "." + request.data.domain
+                    const origSubDomain = request.data.hostname
+                    site.cnameCloaks[cname] = request.data.hostname
                     request.extractURLData(cnameUrl)
                     request.wasCNAME = true
                     request.originalSubdomain = origSubDomain

--- a/src/trackers/helpers/cname.js
+++ b/src/trackers/helpers/cname.js
@@ -61,7 +61,7 @@ class CNAME {
     static createCnameRecord(request) {
         return {
             "original": request.originalSubdomain,
-            "resolved": request.data.subdomain + "." + request.data.domain
+            "resolved": request.data.hostname
         }
     }
 

--- a/test/cname.test.js
+++ b/test/cname.test.js
@@ -1,0 +1,28 @@
+const assert = require('assert')
+const {describe, it, before} = require('mocha')
+
+const cnameHelper = require('../src/trackers/helpers/cname')
+const URL = require('../src/trackers/helpers/url.js')
+
+
+describe('CNAME helpers', () => {
+    describe('builds CNAME record correctly', () => {
+        const url = 'https://assets.targetimg1.com/ssx/ssx.mod.js'
+        const request = {
+            url,
+            data: new URL(url)
+        }
+        const cname = 'target-opus.map.fastly.net'
+        // based on site.js#218
+        const origSubDomain = request.data.subdomain + "." + request.data.domain
+        request.data = new URL(`http://${cname}`)
+        request.wasCNAME = true
+        request.originalSubdomain = origSubDomain
+
+        const cnameRecord = cnameHelper.createCnameRecord(request)
+        assert.deepStrictEqual(cnameRecord, {
+            original: 'assets.targetimg1.com',
+            resolved: 'target-opus.map.fastly.net'
+        })
+    })
+})


### PR DESCRIPTION
When building CNAME records we were concatenating the request domain's `subdomain` and `domain` (eTLD+1) to build the CNAME hostname. However, the `subdomain` can be empty, meaning we'd create a `.` prefixed domain. This PR fixes this, by just using the domain's `hostname` attribute directly.