### PR TITLE
Update entity data in-memory and write files only once

### DIFF
--- a/src/trackers/classes/site.js
+++ b/src/trackers/classes/site.js
@@ -1,6 +1,4 @@
 const tldts = require('tldts-experimental')
-const fs = require('fs')
-const path = require('path')
 const Request = require('./request.js')
 const shared = require('./../helpers/sharedData.js')
 const URL = require('./../helpers/url.js')
@@ -142,63 +140,12 @@ function isRootSite(request, site) {
 }
 
 /**
- * Add domain to entity property list when nameserver match is found. 
- * @param {string} entityName - entity file name to update
- * @param {string} domain - domain name to add to the entity properties list
- */
-function _updateEntityProperties (entityName, domain) {
-    const entityFile = path.join(shared.config.trackerDataLoc, 'entities', `${entityName}.json`)
-
-    fs.readFile(entityFile, 'utf8', (readError, data) => {
-        if (readError) {
-            console.error(readError)
-        } else {
-            const entityData = JSON.parse(data)
-            if (!entityData.properties.includes(domain)) {
-                entityData.properties.push(domain)
-                fs.writeFile(entityFile, JSON.stringify(entityData, null, 4), writeError => {
-                    if (writeError) {
-                        console.error(writeError)
-                    }
-                })
-            }
-        }
-    })
-}
-
-/**
  *  Process a single request, resolve CNAME's (if any)
  *  @param {Object} requestData - The raw request data
  *  @param {Site} site - the current site object
  */
 async function _processRequest (requestData, site) {
     const request = new Request(requestData, site)
-
-    if (!site.isFirstParty(request.url)) {
-        const nameservers = await shared.nameservers.resolveNs(request.domain)
-
-        if (nameservers && nameservers.length) {
-            request.nameservers = nameservers
-
-            // The option to group by nameservers is set in the config
-            // All nameservers must match so we can do a quick check to see that the first nameserver exists in our data
-            if (shared.nameserverList && shared.nameserverToEntity[request.nameservers[0]]) {
-                for (const nsEntry of shared.nameserverList) {
-                    const entityNS = new Set(nsEntry.nameservers)
-                    
-                    // all nameservers in set must match
-                    const nsDiff = request.nameservers.filter(x => !entityNS.has(x))
-                
-                    // eslint-disable-next-line max-depth 
-                    if (nsDiff && nsDiff.length === 0) {
-                        _updateEntityProperties(nsEntry.name, request.domain)
-                        request.owner = nsEntry.name
-                        break
-                    }
-                }
-            }
-        }
-    }
 
     // If this request is a subdomain of the site, see if it is cnamed
     if (site.isFirstParty(request.url) &&

--- a/src/trackers/process-crawl.js
+++ b/src/trackers/process-crawl.js
@@ -31,7 +31,7 @@ async function processSite(siteData) {
     }
 
     // update crawl level domain prevalence, entity prevalence, and fingerprinting
-    crawl.processSite(site)
+    await crawl.processSite(site)
     crawl.stats.sites++
     bar.tick()
 }
@@ -55,6 +55,7 @@ async function processCrawl() {
             sitesQueue.push(processSite(siteData))
         }
         await Promise.allSettled(sitesQueue)
+        crawl.exportEntities()
         crawl.finalizeRequests()
         crawl.writeSummaries()
         console.log(`${chalk.blue(crawl.stats.sites)} sites processed\n${chalk.blue(crawl.stats.requests)} requests processed\n${chalk.blue(crawl.stats.requestsSkipped)} requests skipped`)

--- a/test/process-crawl.test.js
+++ b/test/process-crawl.test.js
@@ -30,7 +30,7 @@ describe('Process Crawl', () => {
             await site.processRequest(request)
             crawl.stats.requests++
         }
-        crawl.processSite(site)
+        await crawl.processSite(site)
         Object.values(crawl.commonRequests).forEach(req => req.finalize(2))
     })
 


### PR DESCRIPTION
- Fixes a race condition with concurrent writing into an entity file
- Speeds things up a bit by avoiding unnecessary file parsing