### PR TITLE
Fix category parsing of quoted headers

### DIFF
--- a/src/trackers/helpers/getCategory.js
+++ b/src/trackers/helpers/getCategory.js
@@ -1,32 +1,28 @@
 const fs = require('fs')
-const _ = require('underscore')
 const parse = require('csv-parse/lib/sync')
 
 function getCategories (categoryCSVfilePath) {
-    const categoryCSV = fs.readFileSync(categoryCSVfilePath, 'utf8').split('\n')
-    const categoryHeader = categoryCSV.shift()
-        .replace(/\r/gi, "")
-        .split(',').slice(1)
+    const records = parse(fs.readFileSync(categoryCSVfilePath, 'utf8'), {
+        columns: true,
+        delimiter: ',',
+    })
+    console.log(records)
 
-    const domainToCategory = categoryCSV.reduce((obj, row) => {
-        
-        row = parse(row)[0]
-        if (!row) {return obj}
-
-        const domain = row[0]
-
-        // clean up category values. 1 means this is in the category, anything else no idea so skip it
-        const rowArray = Array.from(row.slice(1)).map(c => {
+    const domainToCategory = records.reduce((obj, row) => {
+        const domain = row.domain
+        obj[domain] = row
+        delete row.domain
+        Object.keys(row).forEach(category => {
+            const c = row[category]
             if (c === '1') {
-                return 1
+                row[category] = 1
             } else if (c === '0' || c === '') {
-                return 0
+                row[category] = 0
+            } else {
+                console.log(`unknown category value for ${domain}, ${c}`)
+                row[category] = null
             }
-            console.log(`unknown category value for ${domain}, ${c}`)
-            return null
         })
-
-        obj[domain] = _.object(categoryHeader, rowArray)
         return obj
     }, {})
     return domainToCategory

--- a/test/categories.test.js
+++ b/test/categories.test.js
@@ -1,0 +1,21 @@
+const assert = require('assert')
+const {describe, it, before} = require('mocha')
+const { getCategories } = require('../src/trackers/helpers/getCategory')
+
+describe('getCategories', () => {
+    it('generates a domain/category map', () => {
+        const domainToCategpry = getCategories('test/fixtures/categorized_trackers.csv')
+        assert.deepStrictEqual(domainToCategpry, {
+            'ads.com': {
+                'First Category': 1,
+                'Advertising': 1,
+            },
+            'example.com': {
+                'First Category': 0,
+                'Advertising': 1,
+            }
+        })
+    })
+})
+
+

--- a/test/fixtures/categorized_trackers.csv
+++ b/test/fixtures/categorized_trackers.csv
@@ -1,0 +1,3 @@
+domain,"First Category",Advertising
+example.com,,1
+ads.com,1,1


### PR DESCRIPTION
Most CSV parsers will write strings with whitespace with quotes. We recently changed `categorized_trackers.csv` in tracker-radar to go through a parser when being written, which caused some headers to get quoted. To remove any ambiguity when reading that file, this change updates `getCategories` to use the csv library's parsing, which will remove quotes from the header columns. I've also added some tests to confirm it works as expected.